### PR TITLE
[#10] feature: add use case for creating game

### DIFF
--- a/backend/app/adapter/api.py
+++ b/backend/app/adapter/api.py
@@ -1,10 +1,13 @@
 import asyncio
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, APIRouter, status as FastApiHTTPstatus
 from hypercorn.config import Config
 from hypercorn.asyncio import serve
 
 from app.dto import CreateGameReqDto, CreateGameRespDto
+from app.usecase import CreateGameUseCase
+from app.adapter.repository import get_repository
 
 _router = APIRouter(
     prefix="",  # could be API versioning e.g. /v0.0.1/* ,  /v2.0.1/*
@@ -17,15 +20,32 @@ _router = APIRouter(
     },
 )
 
+shared_context = {}
+
 
 @_router.post("/games", response_model=CreateGameRespDto)
 async def create_game(req: CreateGameReqDto):
-    response = CreateGameRespDto(url="https://localhost:8081/games/1234")
+    uc = CreateGameUseCase(
+        repository=shared_context["repository"], settings=shared_context["settings"]
+    )
+    response = await uc.execute(req.players)
     return response
 
 
+@asynccontextmanager
+async def lifetime_server_context(app: FastAPI):
+    # TODO, parameters should be in separate python module or `json` , `toml` file
+    settings = {"host": "localhost:8081"}
+    shared_context["repository"] = get_repository()
+    shared_context["settings"] = settings
+    yield
+    ## TODO, de-initialize the context if necessary,
+    # e.g. close database connections
+    shared_context.clear()
+
+
 def init_app_server() -> FastAPI:
-    app = FastAPI()
+    app = FastAPI(lifespan=lifetime_server_context)
     app.include_router(_router)
     return app
 

--- a/backend/app/adapter/repository/__init__.py
+++ b/backend/app/adapter/repository/__init__.py
@@ -1,0 +1,15 @@
+from app.domain import Game
+
+
+class AbstractRepository:
+    async def save(self, game: Game):
+        raise NotImplementedError("AbstractRepository.save")
+
+
+def get_repository():
+    # TODO
+    # - make it configurable at runtime
+    # - set max limit of concurrent and ongoing games to save
+    from .in_mem import InMemoryRepository
+
+    return InMemoryRepository()

--- a/backend/app/adapter/repository/in_mem.py
+++ b/backend/app/adapter/repository/in_mem.py
@@ -1,0 +1,8 @@
+from app.domain import Game
+from app.adapter.repository import AbstractRepository
+
+
+class InMemoryRepository(AbstractRepository):
+    # TODO, use one-dimensional array to keep the game model instances
+    async def save(self, game: Game):
+        pass

--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -1,0 +1,1 @@
+from .game import Game, GameError, Investigator  # noqa: F401

--- a/backend/app/domain/game.py
+++ b/backend/app/domain/game.py
@@ -1,0 +1,49 @@
+from enum import Enum, auto
+from typing import List, Optional
+
+from app.dto import PlayerDto
+from .player import Player
+
+
+class Difficulty(Enum):
+    INTRODUCTORY = auto()
+
+
+class Investigator(Enum):
+    HUNTER = auto()
+    DRIVER = auto()
+
+
+class GameError(Exception):
+    pass
+
+
+class Game:
+    MAX_NUM_PLAYERS = 4
+
+    def __init__(self, difficult_level: Difficulty = Difficulty.INTRODUCTORY):
+        # TODO, declare setter for difficulty level
+        self._difficulty: Difficulty = difficult_level
+        self._players: List[Player] = []
+
+    def add_players(self, players: List[PlayerDto]):
+        # TODO,
+        # - convert to player domain models
+        # - return error if necessary
+        pass
+
+    @property
+    def id(self):
+        # TODO, generate game ID
+        return "x1234"
+
+    @property
+    def players(self) -> List[Player]:
+        return self._players
+
+    def assign_character(
+        self, player: Player, investigator: Investigator
+    ) -> Optional[GameError]:
+        # TODO, possible errors are :
+        # no-such-player, investigator-already-chosen, game-already-started
+        pass

--- a/backend/app/domain/game.py
+++ b/backend/app/domain/game.py
@@ -26,7 +26,7 @@ class Game:
         self._difficulty: Difficulty = difficult_level
         self._players: List[Player] = []
 
-    def add_players(self, players: List[PlayerDto]):
+    def add_players(self, player_dtos: List[PlayerDto]):
         # TODO,
         # - convert to player domain models
         # - return error if necessary

--- a/backend/app/domain/player.py
+++ b/backend/app/domain/player.py
@@ -1,0 +1,3 @@
+class Player:
+    def __init__(self, _id: str, nickname: str):
+        pass

--- a/backend/app/usecase/__init__.py
+++ b/backend/app/usecase/__init__.py
@@ -1,0 +1,1 @@
+from .create_game import CreateGameUseCase  # noqa: F401

--- a/backend/app/usecase/create_game.py
+++ b/backend/app/usecase/create_game.py
@@ -1,0 +1,38 @@
+import random
+from typing import List, Dict
+from app.dto import PlayerDto, CreateGameRespDto
+from app.domain import Game, GameError, Investigator
+
+
+class AbstractUseCase:
+    def __init__(self, repository, settings: Dict):
+        self.repository = repository
+        self.settings = settings
+
+
+class CreateGameUseCase(AbstractUseCase):
+    async def execute(self, data: List[PlayerDto]) -> CreateGameRespDto:
+        game = Game()
+        # Note this game backend interacts only with the Game Lobby
+        # Platform in GaaS, the Lobby Platform backend is responsible
+        # to send appropriate number of players to this game backend,
+        # it does so by referring to the profile provided in game registration
+        game.add_players(data[: Game.MAX_NUM_PLAYERS])
+        errors = self.rand_select_investigator(game)
+        assert len(errors) == 0
+        await self.repository.save(game)
+        url = "https://{}/games/{}".format(self.settings["host"], game.id)
+        return CreateGameRespDto(url=url)
+
+    def rand_select_investigator(self, game: Game) -> List[GameError]:
+        options = random.shuffle(list(Investigator))
+
+        def fn1(p):
+            c = options.pop(0)
+            return game.assign_character(p, c)
+
+        def fn2(err):
+            return err is not None
+
+        iterator = filter(fn2, map(fn1, game.players))
+        return list(iterator)

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -481,13 +481,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pytest"
-version = "7.4.2"
+version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
-    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
+    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
+    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
 ]
 
 [package.dependencies]
@@ -498,6 +498,24 @@ pluggy = ">=0.12,<2.0"
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.21.1"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "ruff"
@@ -581,4 +599,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "03afa5bdad32b9d56453b43868e6a815deae50a8b9a6b695e366479f6fbcadbe"
+content-hash = "ef9e9ad74b4a76454a8349be1f75bc4af3b1ebdcf939c9ca1ef8b1b73e971423"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,8 @@ hypercorn = "^0.14"
 [tool.poetry.group.test]
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7.4.2"
+pytest = "^7.4.3"
+pytest-asyncio = "^0.21.1"
 httpx = "^0.25"
 
 [tool.poetry.group.dev]

--- a/backend/tests/e2e/test_game.py
+++ b/backend/tests/e2e/test_game.py
@@ -1,16 +1,24 @@
 from fastapi.testclient import TestClient
+import pytest
+
 from app.adapter.api import init_app_server
 
 
+@pytest.fixture(scope="session")
+def test_client():
+    with TestClient(
+        app=init_app_server(),
+        base_url="http://localhost:8081",
+        raise_server_exceptions=True,
+    ) as _client:
+        yield _client
+
+
 class TestGame:
-    def test_create_game_ok(self):
-        app = init_app_server()
-        client = TestClient(
-            app=app, base_url="http://localhost:8081", raise_server_exceptions=True
-        )
+    def test_create_game_ok(self, test_client):
         url = "/games"
         reqbody = {"players": [{"id": "9487", "nickname": "cowbell"}]}
-        response = client.post(url, headers={}, json=reqbody)
+        response = test_client.post(url, headers={}, json=reqbody)
         assert response.status_code == 200
         respbody = response.json()
         assert respbody.get("url") is not None

--- a/backend/tests/unit/usecase/test_game.py
+++ b/backend/tests/unit/usecase/test_game.py
@@ -1,0 +1,49 @@
+import pytest
+from app.dto import PlayerDto
+from app.domain import Game
+from app.adapter.repository import AbstractRepository
+from app.usecase import CreateGameUseCase
+
+
+class MockRepository(AbstractRepository):
+    def __init__(self, save_error=None):
+        self._save_error = save_error
+
+    async def save(self, game: Game):
+        if self._save_error:
+            raise self._save_error
+
+
+class UnitTestError(Exception):
+    pass
+
+
+class TestCreateGame:
+    @pytest.mark.asyncio
+    async def test_ok(self):
+        repository = MockRepository()
+        settings = {"host": "unit.test.app.com"}
+        data = [
+            PlayerDto(id="x8eu3L", nickname="Sheep"),
+            PlayerDto(id="8e1u3g", nickname="Lamb"),
+            PlayerDto(id="h4oOp0", nickname="Llama"),
+            PlayerDto(id="R0fj1B", nickname="Goat"),
+        ]
+        uc = CreateGameUseCase(repository, settings)
+        resp = await uc.execute(data)
+        assert resp.url is not None
+
+    @pytest.mark.asyncio
+    async def test_repo_error(self):
+        repository = MockRepository(save_error=UnitTestError("unit-test"))
+        settings = {"host": "unit.test.app.com"}
+        data = [
+            PlayerDto(id="x8eu3L", nickname="Sheep"),
+            PlayerDto(id="R0fj1B", nickname="Goat"),
+        ]
+        uc = CreateGameUseCase(repository, settings)
+        try:
+            resp = await uc.execute(data)  # noqa: F841
+            assert 0
+        except UnitTestError as e:
+            assert e.args[0] == "unit-test"


### PR DESCRIPTION
Detail
- declare relevant methods to in-memory repository and domain models `Game` and `Player`
- add shared server context that keeps the repository and configuration

Note:
- @teds-lin please help to review the PR, also let me know if you have other ideas about naming the interface of these domain models and repositories.
  - 請協助檢查 PR, 如果你對這些domain model 和 repository 的介面命名有其他想法，請告訴我.
  - apologize for the big commit.
- @wingtkw , I don't send review request to you cuz you're on vacation, if you'd like to learn any part of the code in the PR, leave your comment here (even after this PR is merged) or start another thread in [GitHub Discussion](https://github.com/Game-as-a-Service/Pandemic-Reign-of-Cthulhu/discussions)

Thanks