### PR TITLE
[#11] feature: model and repository of creating game

### DIFF
--- a/backend/app/adapter/repository/__init__.py
+++ b/backend/app/adapter/repository/__init__.py
@@ -5,6 +5,9 @@ class AbstractRepository:
     async def save(self, game: Game):
         raise NotImplementedError("AbstractRepository.save")
 
+    async def get_game(self, game_id: str) -> Game:
+        raise NotImplementedError("AbstractRepository.get_game")
+
 
 def get_repository():
     # TODO

--- a/backend/app/adapter/repository/in_mem.py
+++ b/backend/app/adapter/repository/in_mem.py
@@ -1,8 +1,37 @@
+import threading
+from contextlib import contextmanager
+from typing import Dict
 from app.domain import Game
 from app.adapter.repository import AbstractRepository
 
 
 class InMemoryRepository(AbstractRepository):
-    # TODO, use one-dimensional array to keep the game model instances
+    def __init__(self):
+        self.games = {}
+
+    @contextmanager
+    def games_dict(self) -> Dict[str, Game]:
+        """Provide thread-safe access to the in-memory games dictionary.
+
+        This context manager acquires a lock before yielding the games dict
+        and releases it after, ensuring thread-safe access.
+
+        Yields:
+            Dict[str, Game]: The in-memory games dictionary.
+        """
+        lock = threading.Lock()
+        lock.acquire()
+        try:
+            yield self.games
+        finally:
+            lock.release()
+
     async def save(self, game: Game):
-        pass
+        if not isinstance(game, Game):
+            raise ValueError("game-must-be-a-Game-object")
+        with self.games_dict() as games:
+            games[game.id] = game
+
+    def get_game(self, game_id):
+        with self.games_dict() as games:
+            return games.get(game_id)

--- a/backend/app/adapter/repository/in_mem.py
+++ b/backend/app/adapter/repository/in_mem.py
@@ -1,37 +1,21 @@
-import threading
-from contextlib import contextmanager
-from typing import Dict
+import asyncio
+from typing import Optional
+
 from app.domain import Game
 from app.adapter.repository import AbstractRepository
 
 
 class InMemoryRepository(AbstractRepository):
     def __init__(self):
-        self.games = {}
-
-    @contextmanager
-    def games_dict(self) -> Dict[str, Game]:
-        """Provide thread-safe access to the in-memory games dictionary.
-
-        This context manager acquires a lock before yielding the games dict
-        and releases it after, ensuring thread-safe access.
-
-        Yields:
-            Dict[str, Game]: The in-memory games dictionary.
-        """
-        lock = threading.Lock()
-        lock.acquire()
-        try:
-            yield self.games
-        finally:
-            lock.release()
+        self._lock = asyncio.Lock()
+        self._games = {}
 
     async def save(self, game: Game):
         if not isinstance(game, Game):
             raise ValueError("game-must-be-a-Game-object")
-        with self.games_dict() as games:
-            games[game.id] = game
+        async with self._lock:
+            self._games[game.id] = game
 
-    def get_game(self, game_id):
-        with self.games_dict() as games:
-            return games.get(game_id)
+    async def get_game(self, game_id: str) -> Optional[Game]:
+        async with self._lock:
+            return self._games.get(game_id)

--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -1,1 +1,1 @@
-from .game import Game, GameError, Investigator  # noqa: F401
+from .game import Game, GameError, Investigator, Player  # noqa: F401

--- a/backend/app/domain/game.py
+++ b/backend/app/domain/game.py
@@ -63,9 +63,9 @@ class Game:
         self._players = players
 
     @property
-    def id(self):
+    def id(self) -> str:
         if self._id is None:
-            self._id = uuid4()
+            self._id = str(uuid4())
         return self._id
 
     @property

--- a/backend/app/domain/game.py
+++ b/backend/app/domain/game.py
@@ -1,17 +1,35 @@
 from enum import Enum, auto
 from typing import List, Optional
+from uuid import uuid4
 
 from app.dto import PlayerDto
 from .player import Player
 
 
 class Difficulty(Enum):
+    # 教學難度
     INTRODUCTORY = auto()
+    # 標準難度
+    STANDARD = auto()
+    # 專家難度
+    EXPERT = auto()
 
 
 class Investigator(Enum):
-    HUNTER = auto()
+    # 偵探
+    DETECTIVE = auto()
+    # 博士
+    DOCTOR = auto()
+    # 司機
     DRIVER = auto()
+    # 獵人
+    HUNTER = auto()
+    # 魔術師
+    MAGICIAN = auto()
+    # 神祕學家
+    OCCULTIST = auto()
+    # 記者
+    REPORTER = auto()
 
 
 class GameError(Exception):
@@ -19,31 +37,48 @@ class GameError(Exception):
 
 
 class Game:
+    MIN_NUM_PLAYERS = 2
     MAX_NUM_PLAYERS = 4
 
     def __init__(self, difficult_level: Difficulty = Difficulty.INTRODUCTORY):
+        self._id = None
         # TODO, declare setter for difficulty level
         self._difficulty: Difficulty = difficult_level
         self._players: List[Player] = []
+        # 紀錄每個調查員是否已經被選擇
+        self._investigators = {}
+        for i in Investigator:
+            self._investigators[i] = False
 
-    def add_players(self, player_dtos: List[PlayerDto]):
-        # TODO,
-        # - convert to player domain models
-        # - return error if necessary
-        pass
+    def add_players(self, player_dtos: List[PlayerDto]) -> Optional[GameError]:
+        players = []
+
+        for dto in player_dtos:
+            player = Player(dto.id, dto.nickname)
+            players.append(player)
+
+        if len(players) < self.MIN_NUM_PLAYERS or len(players) > self.MAX_NUM_PLAYERS:
+            raise GameError("incorrect-number-of-players")
+
+        self._players = players
 
     @property
     def id(self):
-        # TODO, generate game ID
-        return "x1234"
+        if self._id is None:
+            self._id = uuid4()
+        return self._id
 
     @property
     def players(self) -> List[Player]:
         return self._players
 
-    def assign_character(
-        self, player: Player, investigator: Investigator
-    ) -> Optional[GameError]:
-        # TODO, possible errors are :
-        # no-such-player, investigator-already-chosen, game-already-started
-        pass
+    def assign_character(self, investigator: Investigator) -> Optional[GameError]:
+        if investigator not in self._investigators:
+            return GameError("invalid-investigator")
+
+        if self._investigators[investigator]:
+            return GameError("investigator-already-chosen")
+
+        self._investigators[investigator] = True
+
+        return None

--- a/backend/app/domain/player.py
+++ b/backend/app/domain/player.py
@@ -1,3 +1,11 @@
 class Player:
-    def __init__(self, _id: str, nickname: str):
-        pass
+    def __init__(self, id: str, nickname: str):
+        self._id = id
+        self._nickname = nickname
+        self._investigator = None
+
+    def set_investigator(self, investigator):
+        self._investigator = investigator
+
+    def get_investigator(self):
+        return self._investigator

--- a/backend/app/usecase/create_game.py
+++ b/backend/app/usecase/create_game.py
@@ -17,7 +17,7 @@ class CreateGameUseCase(AbstractUseCase):
         # Platform in GaaS, the Lobby Platform backend is responsible
         # to send appropriate number of players to this game backend,
         # it does so by referring to the profile provided in game registration
-        game.add_players(data[: Game.MAX_NUM_PLAYERS])
+        game.add_players(data)
         errors = self.rand_select_investigator(game)
         assert len(errors) == 0
         await self.repository.save(game)
@@ -25,11 +25,13 @@ class CreateGameUseCase(AbstractUseCase):
         return CreateGameRespDto(url=url)
 
     def rand_select_investigator(self, game: Game) -> List[GameError]:
-        options = random.shuffle(list(Investigator))
+        options = list(Investigator)
+        random.shuffle(options)
 
         def fn1(p):
             c = options.pop(0)
-            return game.assign_character(p, c)
+            p.set_investigator(c)
+            return game.assign_character(c)
 
         def fn2(err):
             return err is not None

--- a/backend/tests/e2e/test_game.py
+++ b/backend/tests/e2e/test_game.py
@@ -17,7 +17,12 @@ def test_client():
 class TestGame:
     def test_create_game_ok(self, test_client):
         url = "/games"
-        reqbody = {"players": [{"id": "9487", "nickname": "cowbell"}]}
+        reqbody = {
+            "players": [
+                {"id": "9487", "nickname": "Sheep"},
+                {"id": "9527", "nickname": "Goat"},
+            ]
+        }
         response = test_client.post(url, headers={}, json=reqbody)
         assert response.status_code == 200
         respbody = response.json()

--- a/backend/tests/unit/test_in_mem_repo.py
+++ b/backend/tests/unit/test_in_mem_repo.py
@@ -17,40 +17,47 @@ def game():
 @pytest.mark.asyncio
 async def test_save_and_get(repo, game):
     await repo.save(game)
-    assert repo.get_game(game.id) == game
+    assert await repo.get_game(game.id) == game
 
 
-def test_get_not_exist_game(repo):
-    assert repo.get_game("not-exist") is None
+@pytest.mark.asyncio
+async def test_get_not_exist_game(repo):
+    assert await repo.get_game("not-exist") is None
 
 
 @pytest.mark.asyncio
 async def test_duplicate_save(repo, game):
     await repo.save(game)
     await repo.save(game)
-    assert len(repo.games) == 1
+    assert len(repo._games) == 1
 
 
-def test_invalid_game(repo):
-    repo.save("invalid")
-    assert "invalid" not in repo.games
+@pytest.mark.asyncio
+async def test_invalid_game(repo):
+    with pytest.raises(ValueError):
+        await repo.save("invalid")
 
 
 @pytest.mark.asyncio
 async def test_concurrent_access(repo):
+    game = Game()
+    game_id = game.id
+
     # Start task to call save()
-    task = asyncio.create_task(repo.save(Game()))
+    task = asyncio.create_task(repo.save(game))
 
-    # Call get_game() in main thread
-    repo.get_game("id")
-
+    # Wait for save() to complete
     await task
 
-    # Assert no exceptions raised
-    assert True
+    # Call get_game() in main thread
+    result = await repo.get_game(game_id)
+
+    # Assert that get_game() returned the game saved by save()
+    assert result == game
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("game_id", ["game-1", "game-2"])
-def test_get_game(repo, game_id):
-    repo.games[game_id] = Game()
-    assert repo.get_game(game_id) is not None
+async def test_get_game(repo, game_id):
+    repo._games[game_id] = Game()
+    assert await repo.get_game(game_id) is not None

--- a/backend/tests/unit/test_in_mem_repo.py
+++ b/backend/tests/unit/test_in_mem_repo.py
@@ -1,0 +1,56 @@
+import asyncio
+import pytest
+from app.domain import Game
+from app.adapter.repository.in_mem import InMemoryRepository
+
+
+@pytest.fixture
+def repo():
+    return InMemoryRepository()
+
+
+@pytest.fixture
+def game():
+    return Game()
+
+
+@pytest.mark.asyncio
+async def test_save_and_get(repo, game):
+    await repo.save(game)
+    assert repo.get_game(game.id) == game
+
+
+def test_get_not_exist_game(repo):
+    assert repo.get_game("not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_save(repo, game):
+    await repo.save(game)
+    await repo.save(game)
+    assert len(repo.games) == 1
+
+
+def test_invalid_game(repo):
+    repo.save("invalid")
+    assert "invalid" not in repo.games
+
+
+@pytest.mark.asyncio
+async def test_concurrent_access(repo):
+    # Start task to call save()
+    task = asyncio.create_task(repo.save(Game()))
+
+    # Call get_game() in main thread
+    repo.get_game("id")
+
+    await task
+
+    # Assert no exceptions raised
+    assert True
+
+
+@pytest.mark.parametrize("game_id", ["game-1", "game-2"])
+def test_get_game(repo, game_id):
+    repo.games[game_id] = Game()
+    assert repo.get_game(game_id) is not None

--- a/backend/tests/unit/test_investigator.py
+++ b/backend/tests/unit/test_investigator.py
@@ -1,0 +1,37 @@
+import pytest
+from app.domain import Game, Investigator, GameError
+
+
+@pytest.fixture
+def game():
+    return Game()
+
+
+def test_assign_valid(game):
+    err = game.assign_character(Investigator.DETECTIVE)
+    assert err is None
+
+
+def test_assign_invalid(game):
+    game.assign_character(Investigator.DETECTIVE)
+    err = game.assign_character(Investigator.DETECTIVE)
+    assert isinstance(err, GameError)
+    assert err.args[0] == "investigator-already-chosen"
+
+
+def test_assign_invalid2(game):
+    game.assign_character(Investigator.DETECTIVE)
+    game.assign_character(Investigator.HUNTER)
+    err = game.assign_character(Investigator.DETECTIVE)
+    assert isinstance(err, GameError)
+    assert err.args[0] == "investigator-already-chosen"
+
+    err = game.assign_character(Investigator.HUNTER)
+    assert isinstance(err, GameError)
+    assert err.args[0] == "investigator-already-chosen"
+
+
+def test_assign_not_exist(game):
+    err = game.assign_character("unknown")
+    assert isinstance(err, GameError)
+    assert err.args[0] == "invalid-investigator"

--- a/backend/tests/unit/test_player.py
+++ b/backend/tests/unit/test_player.py
@@ -1,0 +1,21 @@
+import pytest
+from app.domain import Player, Investigator
+
+
+@pytest.fixture
+def player():
+    return Player("guQlii", "Player A")
+
+
+def test_set_investigator(player):
+    player.set_investigator(Investigator.DETECTIVE)
+    assert player._investigator == Investigator.DETECTIVE
+
+
+def test_get_investigator(player):
+    player.set_investigator(Investigator.DOCTOR)
+    assert player.get_investigator() == Investigator.DOCTOR
+
+
+def test_not_set(player):
+    assert player.get_investigator() is None

--- a/backend/tests/unit/usecase/test_game.py
+++ b/backend/tests/unit/usecase/test_game.py
@@ -1,6 +1,6 @@
 import pytest
 from app.dto import PlayerDto
-from app.domain import Game
+from app.domain import Game, GameError
 from app.adapter.repository import AbstractRepository
 from app.usecase import CreateGameUseCase
 
@@ -47,3 +47,35 @@ class TestCreateGame:
             assert 0
         except UnitTestError as e:
             assert e.args[0] == "unit-test"
+
+    @pytest.mark.asyncio
+    async def test_only_one_player(self):
+        repository = MockRepository()
+        settings = {"host": "unit.test.app.com"}
+        data = [
+            PlayerDto(id="x8eu3L", nickname="Sheep"),
+        ]
+        uc = CreateGameUseCase(repository, settings)
+        try:
+            resp = await uc.execute(data)  # noqa: F841
+            assert 0
+        except GameError as e:
+            assert e.args[0] == "incorrect-number-of-players"
+
+    @pytest.mark.asyncio
+    async def test_over_four_player(self):
+        repository = MockRepository()
+        settings = {"host": "unit.test.app.com"}
+        data = [
+            PlayerDto(id="x8eu3L", nickname="Sheep"),
+            PlayerDto(id="8e1u3g", nickname="Lamb"),
+            PlayerDto(id="h4oOp0", nickname="Llama"),
+            PlayerDto(id="R0fj1B", nickname="Goat"),
+            PlayerDto(id="oC9TNH", nickname="Alpaca"),
+        ]
+        uc = CreateGameUseCase(repository, settings)
+        try:
+            resp = await uc.execute(data)  # noqa: F841
+            assert 0
+        except GameError as e:
+            assert e.args[0] == "incorrect-number-of-players"


### PR DESCRIPTION
實作以下部份並且新增相關測試案例：

- Domain models
  - Game
   -`add_players()` 
     * 玩家人數限制為2~4人
     * bind Player instances to specific Game instance
  - `id` , identifier could be generated in UUID v4 format
  - `assign_character()`, 僅紀錄目前哪些調查員已被選擇，具體那個玩家選擇那個調查員由`Player class`紀錄


- Player
  - 紀錄選擇那個調查員


- In-memory repository
  - `InMemoryRepository.save()` 
    - Using hash table to store key (game ID) value (relevant Game instance) pairs
    - Provide thread-safe access to the in-memory games dictionary