### PR TITLE
[#10] refactor: change code due to separation of concern

### DIFF
--- a/backend/app/adapter/api.py
+++ b/backend/app/adapter/api.py
@@ -12,17 +12,17 @@ from app.dto import (
     ListInvestigatorsDto,
     UpdateInvestigatorDto,
     UpdateDifficultyDto,
-    UpdateCommonRespDto
+    UpdateCommonRespDto,
 )
 from app.usecase import (
     CreateGameUseCase,
     GetAvailableInvestigatorsUseCase,
     SwitchInvestigatorUseCase,
-    UpdateGameDifficultyUseCase
+    UpdateGameDifficultyUseCase,
 )
 from app.domain import GameError
 from app.adapter.repository import get_repository
-from app.adapter.presenter import read_investigator_presenter
+from app.adapter.presenter import read_investigator_presenter, create_game_presenter
 
 _router = APIRouter(
     prefix="",  # could be API versioning e.g. /v0.0.1/* ,  /v2.0.1/*
@@ -49,7 +49,7 @@ async def create_game(req: CreateGameReqDto):
     uc = CreateGameUseCase(
         repository=shared_context["repository"], settings=shared_context["settings"]
     )
-    response = await uc.execute(req.players)
+    response = await uc.execute(req.players, create_game_presenter)
     return response
 
 
@@ -78,7 +78,7 @@ async def update_game_difficulty(game_id: str, req: UpdateDifficultyDto):
     uc = UpdateGameDifficultyUseCase(
         repository=shared_context["repository"], settings=shared_context["settings"]
     )
-    try: 
+    try:
         response = await uc.execute(game_id, req.level)
         return response
     except GameError as e:

--- a/backend/app/adapter/presenter.py
+++ b/backend/app/adapter/presenter.py
@@ -1,6 +1,11 @@
-from typing import List
+from typing import List, Dict
 
-from app.dto import SingleInvestigatorDto, ListInvestigatorsDto, Investigator
+from app.dto import (
+    SingleInvestigatorDto,
+    ListInvestigatorsDto,
+    Investigator,
+    CreateGameRespDto,
+)
 
 
 def read_investigator_presenter(items: List[Investigator]) -> ListInvestigatorsDto:
@@ -8,3 +13,8 @@ def read_investigator_presenter(items: List[Investigator]) -> ListInvestigatorsD
         return SingleInvestigatorDto(investigator=v)
 
     return list(map(fn1, items))
+
+
+def create_game_presenter(settings: Dict, game_id: str) -> CreateGameRespDto:
+    url = "https://{}/games/{}".format(settings["host"], game_id)
+    return CreateGameRespDto(url=url)

--- a/backend/app/domain/game.py
+++ b/backend/app/domain/game.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from app.dto import PlayerDto, Investigator, Difficulty
 from .player import Player
 
+
 class GameErrorCodes(Enum):
     """
     Elements for each tuple

--- a/backend/app/dto.py
+++ b/backend/app/dto.py
@@ -47,6 +47,7 @@ class UpdateInvestigatorDto(BaseModel):
     investigator: Investigator
     player_id: str
 
+
 class Difficulty(Enum):
     # 教學難度
     INTRODUCTORY = "introductory"
@@ -55,8 +56,10 @@ class Difficulty(Enum):
     # 專家難度
     EXPERT = "expert"
 
+
 class UpdateDifficultyDto(BaseModel):
     level: Difficulty
 
+
 class UpdateCommonRespDto(BaseModel):
-	message: str
+    message: str

--- a/backend/app/usecase/__init__.py
+++ b/backend/app/usecase/__init__.py
@@ -2,5 +2,5 @@ from .config_game import (
     CreateGameUseCase,  # noqa: F401
     GetAvailableInvestigatorsUseCase,  # noqa: F401
     SwitchInvestigatorUseCase,  # noqa: F401
-    UpdateGameDifficultyUseCase #noqa: F401
+    UpdateGameDifficultyUseCase,  # noqa: F401
 )

--- a/backend/app/usecase/config_game.py
+++ b/backend/app/usecase/config_game.py
@@ -1,6 +1,13 @@
 import random
 from typing import List, Dict, Callable, Iterable
-from app.dto import PlayerDto, CreateGameRespDto, Investigator, ListInvestigatorsDto, UpdateCommonRespDto, Difficulty
+from app.dto import (
+    PlayerDto,
+    CreateGameRespDto,
+    Investigator,
+    ListInvestigatorsDto,
+    UpdateCommonRespDto,
+    Difficulty,
+)
 from app.domain import Game, GameError, GameErrorCodes, GameFuncCodes
 
 
@@ -11,7 +18,9 @@ class AbstractUseCase:
 
 
 class CreateGameUseCase(AbstractUseCase):
-    async def execute(self, data: List[PlayerDto]) -> CreateGameRespDto:
+    async def execute(
+        self, data: List[PlayerDto], presenter: Callable[[Dict, str], CreateGameRespDto]
+    ) -> CreateGameRespDto:
         game = Game()
         # Note this game backend interacts only with the Game Lobby
         # Platform in GaaS, the Lobby Platform backend is responsible
@@ -20,8 +29,7 @@ class CreateGameUseCase(AbstractUseCase):
         game.add_players(data)
         self.rand_select_investigator(game)
         await self.repository.save(game)
-        url = "https://{}/games/{}".format(self.settings["host"], game.id)
-        return CreateGameRespDto(url=url)
+        return presenter(self.settings, game.id)
 
     def rand_select_investigator(self, game: Game):
         options = list(Investigator)
@@ -60,6 +68,7 @@ class SwitchInvestigatorUseCase(AbstractUseCase):
 
         game.switch_character(player_id, new_invstg)
         await self.repository.save(game)
+
 
 class UpdateGameDifficultyUseCase(AbstractUseCase):
     async def execute(self, game_id: str, level: Difficulty) -> UpdateCommonRespDto:

--- a/backend/tests/e2e/test_game.py
+++ b/backend/tests/e2e/test_game.py
@@ -76,13 +76,11 @@ class TestGame:
         assert response.status_code == 409
         error_detail = response.json()
         assert error_detail["reason"] == GameErrorCodes.INVESTIGATOR_CHOSEN.value[0]
-    
+
     def test_update_game_difficulty_ok(self, test_client):
         game_id = self.create_game_common(test_client)
         url = "/games/{}/difficulty"
-        reqbody = {
-            "level": "standard"
-        }
+        reqbody = {"level": "standard"}
         response = test_client.patch(url.format(game_id), headers={}, json=reqbody)
         assert response.status_code == 200
         respbody = response.json()
@@ -91,9 +89,7 @@ class TestGame:
 
     def test_update_game_difficulty_nonexist_game(self, test_client):
         url = "/games/{}/difficulty"
-        reqbody = {
-            "level": "standard"
-        }
+        reqbody = {"level": "standard"}
         response = test_client.patch(url.format("xxxxx"), headers={}, json=reqbody)
         assert response.status_code == 404
         error_detail = response.json()

--- a/backend/tests/unit/usecase/test_game.py
+++ b/backend/tests/unit/usecase/test_game.py
@@ -1,8 +1,18 @@
 import pytest
-from app.dto import PlayerDto, SingleInvestigatorDto, ListInvestigatorsDto, UpdateDifficultyDto
+from app.dto import (
+    PlayerDto,
+    SingleInvestigatorDto,
+    ListInvestigatorsDto,
+    UpdateDifficultyDto,
+)
 from app.domain import Game, GameError, GameErrorCodes, GameFuncCodes
 from app.adapter.repository import AbstractRepository
-from app.usecase import CreateGameUseCase, GetAvailableInvestigatorsUseCase, UpdateGameDifficultyUseCase
+from app.adapter.presenter import create_game_presenter
+from app.usecase import (
+    CreateGameUseCase,
+    GetAvailableInvestigatorsUseCase,
+    UpdateGameDifficultyUseCase,
+)
 
 
 class MockRepository(AbstractRepository):
@@ -37,8 +47,9 @@ class TestCreateGame:
             PlayerDto(id="R0fj1B", nickname="Goat"),
         ]
         uc = CreateGameUseCase(repository, settings)
-        resp = await uc.execute(data)
+        resp = await uc.execute(data, create_game_presenter)
         assert resp.url is not None
+        assert len(resp.url) > 0
 
     @pytest.mark.asyncio
     async def test_repo_error(self):
@@ -50,7 +61,7 @@ class TestCreateGame:
         ]
         uc = CreateGameUseCase(repository, settings)
         try:
-            resp = await uc.execute(data)  # noqa: F841
+            resp = await uc.execute(data, create_game_presenter)  # noqa: F841
             assert 0
         except UnitTestError as e:
             assert e.args[0] == "unit-test"
@@ -64,7 +75,7 @@ class TestCreateGame:
         ]
         uc = CreateGameUseCase(repository, settings)
         with pytest.raises(GameError) as e:
-            resp = await uc.execute(data)  # noqa: F841
+            resp = await uc.execute(data, create_game_presenter)  # noqa: F841
             assert e.func_code == GameFuncCodes.ADD_PLAYERS
             assert e.error_code == GameErrorCodes.INCORECT_NUM_PLAYERS
 
@@ -81,7 +92,7 @@ class TestCreateGame:
         ]
         uc = CreateGameUseCase(repository, settings)
         with pytest.raises(GameError) as e:
-            resp = await uc.execute(data)  # noqa: F841
+            resp = await uc.execute(data, create_game_presenter)  # noqa: F841
             assert e.func_code == GameFuncCodes.ADD_PLAYERS
             assert e.error_code == GameErrorCodes.INCORECT_NUM_PLAYERS
 
@@ -102,6 +113,7 @@ class TestGetAvailInvestigatorFromGame:
         result = await uc.execute(mockgame.id, mock_presenter)  # noqa: F841
         assert len(result) == 2
 
+
 class TestUpdateGameDifficulty:
     @pytest.mark.asyncio
     async def test_ok(self):
@@ -112,5 +124,3 @@ class TestUpdateGameDifficulty:
         uc = UpdateGameDifficultyUseCase(repository, settings)
         resp = await uc.execute(mockgame.id, data.level)
         assert resp.message is not None
-
-    


### PR DESCRIPTION
- move DTO generating code from `CreateGameUseCase` to `presenter` module
- re-format the code in previous commit, to meet PEP8 styling

see [my comment](https://github.com/Game-as-a-Service/Pandemic-Reign-of-Cthulhu/issues/10#issuecomment-1810582510) in the issue #10 for motivation.