### PR TITLE
Emit events on difficulty and character update

### DIFF
--- a/backend/app/adapter/api.py
+++ b/backend/app/adapter/api.py
@@ -75,7 +75,10 @@ async def read_unselected_investigators(game_id: str):
 
 @_router.patch("/games/{game_id}/investigator", status_code=200)
 async def switch_investigator(game_id: str, req: UpdateInvestigatorDto):
-    uc = SwitchInvestigatorUseCase(shared_context["repository"])
+    uc = SwitchInvestigatorUseCase(
+        shared_context["repository"],
+        evt_emitter=shared_context["evt_emit"],
+    )
     try:
         await uc.execute(game_id, req.player_id, req.investigator)
     except GameError as e:
@@ -85,7 +88,9 @@ async def switch_investigator(game_id: str, req: UpdateInvestigatorDto):
 @_router.patch("/games/{game_id}/difficulty", response_model=UpdateCommonRespDto)
 async def update_game_difficulty(game_id: str, req: UpdateDifficultyDto):
     uc = UpdateGameDifficultyUseCase(
-        repository=shared_context["repository"], settings=shared_context["settings"]
+        repository=shared_context["repository"],
+        evt_emitter=shared_context["evt_emit"],
+        settings=shared_context["settings"],
     )
     try:
         response = await uc.execute(game_id, req.level)

--- a/backend/app/constant.py
+++ b/backend/app/constant.py
@@ -10,6 +10,8 @@ class GameRtcEvent(Enum):
     DEINIT = "deinit"
     CHAT = "chat"
     NEW_ROOM = "new_room"
+    CHARACTER = "character"
+    DIFFICULTY = "difficulty"
 
 
 class RealTimeCommConst:

--- a/backend/app/dto.py
+++ b/backend/app/dto.py
@@ -7,11 +7,13 @@ from pydantic import BaseModel, RootModel, ConfigDict
 
 
 class PlayerDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     id: str
     nickname: str
 
 
 class CreateGameReqDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     players: List[PlayerDto]
 
 
@@ -37,6 +39,7 @@ class Investigator(Enum):
 
 
 class SingleInvestigatorDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     investigator: Investigator
 
 
@@ -44,6 +47,7 @@ ListInvestigatorsDto = RootModel[List[SingleInvestigatorDto]]
 
 
 class UpdateInvestigatorDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     investigator: Investigator
     player_id: str
 
@@ -58,6 +62,7 @@ class Difficulty(Enum):
 
 
 class UpdateDifficultyDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     level: Difficulty
 
 
@@ -84,3 +89,16 @@ class RtcInitMsgData(BaseModel):
     player: PlayerDto
     gameID: str
     client: str  # client session ID
+
+
+class RtcCharacterMsgData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    gameID: str
+    investigator: Investigator
+    player_id: str
+
+
+class RtcDifficultyMsgData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    gameID: str
+    level: Difficulty

--- a/backend/app/usecase/config_game.py
+++ b/backend/app/usecase/config_game.py
@@ -71,6 +71,8 @@ class SwitchInvestigatorUseCase(AbstractUseCase):
 
         game.switch_character(player_id, new_invstg)
         await self.repository.save(game)
+        if self.evt_emitter:
+            await self.evt_emitter.switch_character(game_id, player_id, new_invstg)
 
 
 class UpdateGameDifficultyUseCase(AbstractUseCase):
@@ -83,5 +85,7 @@ class UpdateGameDifficultyUseCase(AbstractUseCase):
             )
         game.update_difficulty(level)
         await self.repository.save(game)
+        if self.evt_emitter:
+            await self.evt_emitter.update_difficulty(game_id, level)
         message = "Update Game {} Difficulty Successfully".format(game.id)
         return UpdateCommonRespDto(message=message)

--- a/backend/tests/unit/usecase/test_game.py
+++ b/backend/tests/unit/usecase/test_game.py
@@ -121,6 +121,6 @@ class TestUpdateGameDifficulty:
         repository = MockGameRepository(mock_fetched=mockgame)
         settings = {"host": "unit.test.app.com"}
         data = UpdateDifficultyDto(level="standard")
-        uc = UpdateGameDifficultyUseCase(repository, settings)
+        uc = UpdateGameDifficultyUseCase(repository, settings=settings)
         resp = await uc.execute(mockgame.id, data.level)
         assert resp.message is not None


### PR DESCRIPTION
This is the 3rd portion of [the TODO list](https://github.com/Game-as-a-Service/Pandemic-Reign-of-Cthulhu/issues/37#issuecomment-1842635038) in #37 

- http server emits corresponding event on completing the operations to socket.io server
- socket.io server simply forwards the game-state messages to corresponding players of a given game

@wingtkw ,
according to the [previous discussion](https://github.com/Game-as-a-Service/Pandemic-Reign-of-Cthulhu/discussions/8#discussioncomment-7838274) ,
if you happen to see this PR please help to review my code by the end of 1st. Feb 2024 ,
after that I will merge the PR first ,
you are still welcome to leave comment at here,
 or create another issue / discussion thread for any question about my code at here ,
thanks.
